### PR TITLE
Correct printing of month in dataformat wiki page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Checkout npm package.json and related files with LF line-endings
+package.json text eol=lf
+package-lock.json text eol=lf
+

--- a/views/history.html
+++ b/views/history.html
@@ -21,7 +21,7 @@
             <option value="Mo i Rana">Mo i Rana</option>
             <option value="Narvik">Narvik</option>
             <option value="Nord-Troms">Nord-Troms</option>
-            <option value="Tromsø">Tromsø</option>
+            <option value="Tromsø" selected="selected">Tromsø</option>
           </select>
           <div class="col-4" align="center">
             eller

--- a/wiki/Dataformat.md
+++ b/wiki/Dataformat.md
@@ -92,7 +92,7 @@ Serial.print("-");
 if (month < 10) {
   Serial.print("0");
 }
-Serial.print("0");
+Serial.print(month);
 // SEPARATOR
 Serial.print("-");
 // DAY

--- a/wiki/package-lock.json
+++ b/wiki/package-lock.json
@@ -7,13 +7,13 @@
     "@types/highlight.js": {
       "version": "9.12.2",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "integrity": "sha1-bufNOV7/5eyAtRXT/xaZBozQzR0=",
       "dev": true
     },
     "@types/node": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
+      "integrity": "sha1-OhKc2nxOXfJAlwJiaJLLS5ZUbdU=",
       "dev": true
     },
     "escape-html": {


### PR DESCRIPTION
- Fixes a bug in the code that prints date and time in the ISO 8601 format
- **Suggestion:** Auto-select `Tromsø` area by default on history page (currently `Alta` is auto-selected)