### PR TITLE
Update Font Awesome Dependencies

### DIFF
--- a/views/header.html
+++ b/views/header.html
@@ -4,9 +4,6 @@
   crossorigin="anonymous" />
 <!-- Source Code Pro Font -->
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
-<!-- Font Awesome -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0="
-  crossorigin="anonymous" />
 <!-- Leaflet -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" integrity="sha256-iYUgmrapfDGvBrePJPrMWQZDcObdAcStKBpjP3Az+3s="
   crossorigin="anonymous" />

--- a/views/history.html
+++ b/views/history.html
@@ -9,7 +9,7 @@
   </div>
   <div class="col-1" align="center" onmouseover="" style="cursor: pointer;" data-toggle="modal" data-target="#exampleModal">
     <i class="fas fa-question-circle fa-2x" style="margin: 10px;"></i>
-    </br>
+    <br/>
     Slik bruker du søkesiden
   </div>
 </div>
@@ -134,14 +134,14 @@
         <div class=col-6>
           <div id="infobox-PM10" style="display:none;">
             <b>PM10</b>
-            </br> Ingen data tilgjengelig
+            <br/> Ingen data tilgjengelig
           </div>
           <div id="chart-PM10" class="chart" style="display:inline-block;"></div>
         </div>
         <div class=col-6>
           <div id="infobox-NO2" style="display:none;">
             <b>NO2</b>
-            </br> Ingen data tilgjengelig
+            <br/> Ingen data tilgjengelig
           </div>
           <div id="chart-NO2" class="chart" style="display:inline-block;"></div>
         </div>
@@ -373,4 +373,5 @@
       });
     }
   }
+
 </script> {{ end }}

--- a/views/live.html
+++ b/views/live.html
@@ -76,13 +76,13 @@
       <h3>Målinger fra NILU de siste 24 timene</h3>
       <div id="infobox-PM10" style="display:none;">
         <b>PM10</b>
-        </br> Ingen data tilgjengelig
+        <br/> Ingen data tilgjengelig
       </div>
       <div id="chart-PM10" class="chart">
       </div>
       <div id="infobox-NO2" style="display:none;">
         <b>NO2</b>
-        </br> Ingen data tilgjengelig
+        <br/> Ingen data tilgjengelig
       </div>
       <div id="chart-NO2" class="chart">
       </div>

--- a/views/scripts.html
+++ b/views/scripts.html
@@ -48,7 +48,11 @@
 <!-- moment.js -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.21.0/moment.min.js" integrity="sha256-9YAuB2VnFZNJ+lKfpaQ3dKQT9/C0j3VUla76hHbiVF8="
   crossorigin="anonymous"></script>
-
+<!-- Font Awesome -->
+<script defer src="https://use.fontawesome.com/releases/v5.0.8/js/solid.js" integrity="sha384-+Ga2s7YBbhOD6nie0DzrZpJes+b2K1xkpKxTFFcx59QmVPaSA8c7pycsNaFwUK6l"
+  crossorigin="anonymous"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.0.8/js/fontawesome.js" integrity="sha384-7ox8Q2yzO/uWircfojVuCQOZl+ZZBg2D2J5nkpLqzH1HY0C1dHlTKIbpRz/LG23c"
+  crossorigin="anonymous"></script>
 
 <script type="text/javascript" src="/public/js/vis.js"></script>
 <script type="text/javascript" src="/public/js/history.js"></script>


### PR DESCRIPTION
On the history-page the button for the modal showing instructions on how to use the maps should display a Font Awesome question-circle icon.

Commit 1097f04 fixes these issues by removing the legacy reference the old Font Awesome CSS and changing it to their new *SVG with JS* serving model. For that we unfortunenately need to make use of the Font Awesome CDN which will cause a Browser not to be able to share previous connections, but that is okay, since the Font Awesome dependencies are lazily loaded through JavaScript at the very end of the webpage rendering.