### PR TITLE
Wiki uses the same templating engine as the rest of the site

### DIFF
--- a/controllers/wiki.go
+++ b/controllers/wiki.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+func wikiTemplateHandler(w http.ResponseWriter, r *http.Request, reqPath string) {
+	wikiTemplate, err := template.ParseFiles("views/base.html",
+		"views/header.html", "views/navbar.html", "views/navbar2.html",
+		"views/wiki.html", "views/footer.html", "views/scripts.html",
+		filepath.Join(".", reqPath))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	err = wikiTemplate.Execute(w, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+}
+
+func WikiHandler(w http.ResponseWriter, r *http.Request) {
+	reqPath := r.URL.Path
+	reqExt := strings.ToUpper(path.Ext(reqPath))
+	if reqExt == ".HTML" || reqExt == ".HTM" {
+		wikiTemplateHandler(w, r, reqPath)
+		return
+	}
+
+	http.ServeFile(w, r, filepath.Join(".", reqPath))
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
 	"github.com/fjukstad/luft/controllers"
 	// "github.com/luft-1/controllers"
 )
@@ -18,6 +19,7 @@ func main() {
 	mux.HandleFunc("/precipitation", controllers.PrecipitationHandler)
 	mux.HandleFunc("/sendfile", controllers.PostFileHandler)
 
+	mux.HandleFunc("/public/wiki/", controllers.WikiHandler)
 	mux.Handle("/public/", http.FileServer(http.Dir(".")))
 
 	mux.HandleFunc("/", controllers.IndexHandler)

--- a/views/header.html
+++ b/views/header.html
@@ -4,9 +4,6 @@
   crossorigin="anonymous" />
 <!-- Source Code Pro Font -->
 <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
-<!-- Font Awesome -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0="
-  crossorigin="anonymous" />
 <!-- Leaflet -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css" integrity="sha256-iYUgmrapfDGvBrePJPrMWQZDcObdAcStKBpjP3Az+3s="
   crossorigin="anonymous" />

--- a/views/history.html
+++ b/views/history.html
@@ -9,7 +9,7 @@
   </div>
   <div class="col-1" align="center" onmouseover="" style="cursor: pointer;" data-toggle="modal" data-target="#exampleModal">
     <i class="fas fa-question-circle fa-2x" style="margin: 10px;"></i>
-    </br>
+    <br/>
     Slik bruker du søkesiden
   </div>
 </div>
@@ -134,14 +134,14 @@
         <div class=col-6>
           <div id="infobox-PM10" style="display:none;">
             <b>PM10</b>
-            </br> Ingen data tilgjengelig
+            <br/> Ingen data tilgjengelig
           </div>
           <div id="chart-PM10" class="chart" style="display:inline-block;"></div>
         </div>
         <div class=col-6>
           <div id="infobox-NO2" style="display:none;">
             <b>NO2</b>
-            </br> Ingen data tilgjengelig
+            <br/> Ingen data tilgjengelig
           </div>
           <div id="chart-NO2" class="chart" style="display:inline-block;"></div>
         </div>
@@ -373,4 +373,5 @@
       });
     }
   }
+
 </script> {{ end }}

--- a/views/live.html
+++ b/views/live.html
@@ -76,13 +76,13 @@
       <h3>Målinger fra NILU de siste 24 timene</h3>
       <div id="infobox-PM10" style="display:none;">
         <b>PM10</b>
-        </br> Ingen data tilgjengelig
+        <br/> Ingen data tilgjengelig
       </div>
       <div id="chart-PM10" class="chart">
       </div>
       <div id="infobox-NO2" style="display:none;">
         <b>NO2</b>
-        </br> Ingen data tilgjengelig
+        <br/> Ingen data tilgjengelig
       </div>
       <div id="chart-NO2" class="chart">
       </div>

--- a/views/scripts.html
+++ b/views/scripts.html
@@ -48,7 +48,11 @@
 <!-- moment.js -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.21.0/moment.min.js" integrity="sha256-9YAuB2VnFZNJ+lKfpaQ3dKQT9/C0j3VUla76hHbiVF8="
   crossorigin="anonymous"></script>
-
+<!-- Font Awesome -->
+<script defer src="https://use.fontawesome.com/releases/v5.0.8/js/solid.js" integrity="sha384-+Ga2s7YBbhOD6nie0DzrZpJes+b2K1xkpKxTFFcx59QmVPaSA8c7pycsNaFwUK6l"
+  crossorigin="anonymous"></script>
+<script defer src="https://use.fontawesome.com/releases/v5.0.8/js/fontawesome.js" integrity="sha384-7ox8Q2yzO/uWircfojVuCQOZl+ZZBg2D2J5nkpLqzH1HY0C1dHlTKIbpRz/LG23c"
+  crossorigin="anonymous"></script>
 
 <script type="text/javascript" src="/public/js/vis.js"></script>
 <script type="text/javascript" src="/public/js/history.js"></script>

--- a/views/wiki.html
+++ b/views/wiki.html
@@ -1,0 +1,5 @@
+{{ define "content" }}
+{{ template "navbar2" . }}
+{{ template "wikipage" }}
+{{ template "scripts" . }}
+{{ end }}

--- a/wiki/airbit.uit.no.wiki.template.html
+++ b/wiki/airbit.uit.no.wiki.template.html
@@ -1,84 +1,15 @@
-<!DOCTYPE html>
-<html lang="nb-NO" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta http-equiv="content-type" charset="utf-8" />
-    <title>d792aafa37404406b4ea8f526b479e01 &ndash; air:bit Wiki</title>
-
-    <!-- Boots -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ"
-        crossorigin="anonymous">
-    <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb"
-        crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8"
-        crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk="
-        crossorigin="anonymous" />
-    <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
-    <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8="
-        crossorigin="anonymous"></script>
-    <script src='http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js'></script>
-    <!-- Leaflet -->
-    <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.1/dist/leaflet.css" />
-    <!-- d3 -->
-    <script src="https://d3js.org/d3.v4.min.js"></script>
-    <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-        ga('create', 'UA-93186535-1', 'auto');
-        ga('send', 'pageview');</script>
-    <link rel="stylesheet" href="/public/css/style.css" />
-    <script src="/public/js/vis.js"></script>
-</head>
-<body>
-    <nav class="navbar navbar-toggleable-md navbar-light bg-faded">
-        <button class="navbar-toggler navbar-toggler-right custom-toggler" type="button" data-toggle="collapse" data-target="#navbar"
-            aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <a class="navbar-brand" href="/">air:bit</a>
-        <div class="collapse navbar-collapse" id="navbar">
-            <ul class="navbar-nav mr-auto"></ul>
-            <ul class="navbar-nav my-2 my-lg-0">
-                <li class="nav-item">
-                    <!-- <a class="nav-link" target="_blank" href="https://luft-184208.appspot.com/">Last opp data<span class="sr-only">(current)</span></a> -->
-                    <a class="nav-link" href="/lastopp">Last opp data</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="/historikk">Søk i tid</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="/live">Live</a>
-                </li>
-            </ul>
-        </div>
-    </nav>
-    <div class="main">
-        <div class="container container-fluid">
-            <div class="row">
-                <div class="col-xs-12 col-sm-9 col-sm-pull-3">
-                    <div class="markdown">
-                        <h1>d792aafa37404406b4ea8f526b479e01</h1>
-                        <hr />
-                        c81addc8f61b4d8da7418500fb88b242
-                    </div>
-                </div>
-                <div class="col-xs-12 col-sm-3 col-sm-push-9 well">
-                    ca68a7c31184428f8a99ec8b9bc15dba
-                </div>
-            </div>
-        </div>
+{{ define "wikipage" }}
+<div class="container">
+  <div class="row">
+    <div class="col-xs-12 col-sm-9 col-sm-pull-3">
+      <div class="markdown">
+        <h1>d792aafa37404406b4ea8f526b479e01</h1>
+        <hr /> c81addc8f61b4d8da7418500fb88b242
+      </div>
     </div>
-    <footer id="footer" class="footer">ed3c8e5ccb9c488e90fb78b1cbd3c99d</footer>
-</body>
-</html>
+    <div class="col-xs-12 col-sm-3 col-sm-push-9 well">
+      ca68a7c31184428f8a99ec8b9bc15dba
+    </div>
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
Wiki pages get the benefit of having the same Headers, Footers, Navbars and layout as all other pages on the site.

This is done by creating a new Wiki-Controller that loads the requested site in `public/wiki/` and renders it by executing the same template that is used for the site Homepage.

Previously changes made to the layout of Wiki-pages did not affect the ususal pages, and vice-versa. This PR fixes this by treating wiki-pages just as normal HTML pages that are no different from the other (index, lastopp, historikk) pages.

This will remove the need to fix up issues with the headers, scripts or layout of the page in multiple places. Changes made to the view-files will also affect the Wiki-pages, and the look of the site will thus remain consistent for all pages.
